### PR TITLE
Fix config readme for elasticsearch 7.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Open `elasticsearch.yml` and add the following configuration:
 http.cors.enabled : true
 http.cors.allow-origin : "*"
 http.cors.allow-credentials: true
-http.cors.allow-methods : OPTIONS, HEAD, GET, POST, PUT, DELETE
-http.cors.allow-headers : kbn-version, Origin, X-Requested-With, Content-Type, Accept, Engaged-Auth-Token, Content-Length, Authorization
+http.cors.allow-methods : OPTIONS,HEAD,GET,POST,PUT,DELETE
+http.cors.allow-headers : kbn-version,Origin,X-Requested-With,Content-Type,Accept,Engaged-Auth-Token,Content-Length,Authorization
 ```
 
 ## Step 3: Enable CORS for Kibana


### PR DESCRIPTION
We experienced this issue (https://discuss.elastic.co/t/elasticsearch-not-working-with-cors/79152) when trying to setup CORS.
This bug in elasticsearch was supposedly fixed a long time ago, but from what we experienced it still happens and removing the white spaces actually solved it in 7.3.0, so maybe there was a regression (or maybe just coincidence, but it doesn't seem to hurt to remove the white spaces just to be safe).